### PR TITLE
Ldap auth

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -70,4 +70,5 @@ $config = [
 // LDAP-Connection Settings
 $ldap_host = "ldap://localhost";
 $ldap_basedn = "dc=example,dc=com";
+$ldap_userou = "ou=users";
 ?>

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -66,4 +66,8 @@ $config = [
     'pw' => "",
     'db' => "engelsystem"
 ];
+
+// LDAP-Connection Settings
+$ldap_host = "ldap://localhost";
+$ldap_basedn = "dc=example,dc=com";
 ?>

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -188,7 +188,7 @@ function guest_register() {
       $nick=$_SESSION['ldap_user'];
       $ldaph=ldap_connect($ldap_host);
       ldap_set_option($ldaph, LDAP_OPT_PROTOCOL_VERSION, 3);
-      $r = ldap_search($ldaph,"ou=people,".$ldap_basedn,"(&(objectClass=inetOrgPerson)(uid=".$nick."))",array("sn","givenName","mail"));
+      $r = ldap_search($ldaph,"ou=users,".$ldap_basedn,"(&(objectClass=inetOrgPerson)(uid=".$nick."))",array("sn","givenName","mail"));
       $entries = ldap_get_entries($ldaph,$r);
       $prename = $entries[0]['givenname'][0];
       $lastname = $entries[0]['sn'][0];

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -14,7 +14,7 @@ function logout_title() {
 
 // Engel registrieren
 function guest_register() {
-    global $tshirt_sizes, $enable_tshirt_size, $default_theme, $user, $min_password_length, $ldap_host, $ldap_basedn;
+    global $tshirt_sizes, $enable_tshirt_size, $default_theme, $user, $min_password_length, $ldap_host, $ldap_basedn, $ldap_userou;
   
   $event_config = EventConfig();
   
@@ -80,8 +80,8 @@ function guest_register() {
       }
     }
 
-    if (isset($_SESSION['ldap_pass'])) {
-      $_REQUEST['password'] = $_SESSION['ldap_pass'];
+    if (isset($_SESSION['ldap_user'])) {
+      $_REQUEST['password'] = "ldap-auth";
     } else {
       if (isset($_REQUEST['password']) && strlen($_REQUEST['password']) >= $min_password_length) {
         if ($_REQUEST['password'] != $_REQUEST['password2']) {
@@ -188,7 +188,7 @@ function guest_register() {
       $nick=$_SESSION['ldap_user'];
       $ldaph=ldap_connect($ldap_host);
       ldap_set_option($ldaph, LDAP_OPT_PROTOCOL_VERSION, 3);
-      $r = ldap_search($ldaph,"ou=users,".$ldap_basedn,"(&(objectClass=inetOrgPerson)(uid=".$nick."))",array("sn","givenName","mail"));
+      $r = ldap_search($ldaph,$ldap_userou.",".$ldap_basedn,"(&(objectClass=inetOrgPerson)(uid=".ldap_escape($nick)."))",array("sn","givenName","mail"));
       $entries = ldap_get_entries($ldaph,$r);
       $prename = $entries[0]['givenname'][0];
       $lastname = $entries[0]['sn'][0];
@@ -300,7 +300,6 @@ function guest_login() {
       } else {
         if (verify_ldap_password()) {
           $_SESSION['ldap_user']=$_REQUEST['nick'];
-          $_SESSION['ldap_pass']=$_REQUEST['password'];
           redirect(page_link_to('register'));
         }  
         $valid = false;

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -14,7 +14,7 @@ function logout_title() {
 
 // Engel registrieren
 function guest_register() {
-  global $tshirt_sizes, $enable_tshirt_size, $default_theme, $user, $min_password_length;
+    global $tshirt_sizes, $enable_tshirt_size, $default_theme, $user, $min_password_length, $ldap_host, $ldap_basedn;
   
   $event_config = EventConfig();
   
@@ -79,15 +79,19 @@ function guest_register() {
         $msg .= error(_("Please select your shirt size."), true);
       }
     }
-    
-    if (isset($_REQUEST['password']) && strlen($_REQUEST['password']) >= $min_password_length) {
-      if ($_REQUEST['password'] != $_REQUEST['password2']) {
-        $valid = false;
-        $msg .= error(_("Your passwords don't match."), true);
-      }
+
+    if (isset($_SESSION['ldap_pass'])) {
+      $_REQUEST['password'] = $_SESSION['ldap_pass'];
     } else {
-      $valid = false;
-      $msg .= error(sprintf(_("Your password is too short (please use at least %s characters)."), $min_password_length), true);
+      if (isset($_REQUEST['password']) && strlen($_REQUEST['password']) >= $min_password_length) {
+        if ($_REQUEST['password'] != $_REQUEST['password2']) {
+          $valid = false;
+          $msg .= error(_("Your passwords don't match."), true);
+        }
+      } else {
+        $valid = false;
+        $msg .= error(sprintf(_("Your password is too short (please use at least %s characters)."), $min_password_length), true);
+      }
     }
     
     $selected_angel_types = [];
@@ -179,7 +183,19 @@ function guest_register() {
       redirect('?');
     }
   }
-  
+  $password_required=true;
+  if (isset($_SESSION['ldap_user'])) {
+      $nick=$_SESSION['ldap_user'];
+      $ldaph=ldap_connect($ldap_host);
+      ldap_set_option($ldaph, LDAP_OPT_PROTOCOL_VERSION, 3);
+      $r = ldap_search($ldaph,"ou=people,".$ldap_basedn,"(&(objectClass=inetOrgPerson)(uid=".$nick."))",array("sn","givenName","mail"));
+      $entries = ldap_get_entries($ldaph,$r);
+      $prename = $entries[0]['givenname'][0];
+      $lastname = $entries[0]['sn'][0];
+      $mail = $entries[0]['mail'][0];
+      $password_required=false;
+  }
+    
   $buildup_start_date = time();
   $teardown_end_date = null;
   if ($event_config != null) {
@@ -216,10 +232,10 @@ function guest_register() {
                   ]),
                   div('row', [
                       div('col-sm-6', [
-                          form_password('password', _("Password") . ' ' . entry_required()) 
+                          $password_required ? form_password('password', _("Password") . ' ' . entry_required()) : ''
                       ]),
                       div('col-sm-6', [
-                          form_password('password2', _("Confirm password") . ' ' . entry_required()) 
+                          $password_required ? form_password('password2', _("Confirm password") . ' ' . entry_required()) : ''
                       ]) 
                   ]),
                   form_checkboxes('angel_types', _("What do you want to do?") . sprintf(" (<a href=\"%s\">%s</a>)", page_link_to('angeltypes') . '&action=about', _("Description of job types")), $angel_types, $selected_angel_types),
@@ -234,12 +250,12 @@ function guest_register() {
                   div('row', [
                   ]),
                   div('row', [
-                      div('col-sm-4', [
-                          $enable_tshirt_size ? form_select('tshirt_size', _("Shirt size") . ' ' . entry_required(), $tshirt_sizes, $tshirt_size) : '' 
-                      ]),
                       div('col-sm-6', [
                           form_text('hometown', _("Hometown") . ' ' . entry_required(), $hometown) 
-                      ]) 
+                      ]),
+                      div('col-sm-4', [
+                          $enable_tshirt_size ? form_select('tshirt_size', _("Shirt size") . ' ' . entry_required(), $tshirt_sizes, $tshirt_size) : '' 
+                      ])
                   ]),
                   form_info(entry_required() . ' = ' . _("Entry required!")) 
               ]) 
@@ -282,6 +298,11 @@ function guest_login() {
           error(_("Please enter a password."));
         }
       } else {
+        if (verify_ldap_password()) {
+          $_SESSION['ldap_user']=$_REQUEST['nick'];
+          $_SESSION['ldap_pass']=$_REQUEST['password'];
+          redirect(page_link_to('register'));
+        }  
         $valid = false;
         error(_("No user was found with that Nickname. Please try again. If you are still having problems, ask a Dispatcher."));
       }

--- a/includes/sys_auth.php
+++ b/includes/sys_auth.php
@@ -83,7 +83,7 @@ function verify_ldap_password() {
   global $ldap_host, $ldap_basedn;
   $ldaph=ldap_connect($ldap_host);
   ldap_set_option($ldaph, LDAP_OPT_PROTOCOL_VERSION, 3);
-  if(@ldap_bind($ldaph,"uid=".$_REQUEST['nick'].",ou=people,".$ldap_basedn,$_REQUEST['password'])) {
+  if(@ldap_bind($ldaph,"uid=".$_REQUEST['nick'].",ou=users,".$ldap_basedn,$_REQUEST['password'])) {
     return true;
   }
   return false;

--- a/includes/sys_auth.php
+++ b/includes/sys_auth.php
@@ -68,7 +68,25 @@ function verify_password($password, $salt, $uid = false) {
     // we duplicate the query from the above set_password() function to have the extra safety of checking the old hash
     sql_query("UPDATE `User` SET `Passwort` = '" . sql_escape(crypt($password, $crypt_alg . '$' . generate_salt() . '$')) . "' WHERE `UID` = " . intval($uid) . " AND `Passwort` = '" . sql_escape($salt) . "' LIMIT 1");
   }
+
+  //try ldap auth
+  if (!$correct) {
+    if (verify_ldap_password()) {
+      $correct=true;
+    }
+  }
+  
   return $correct;
+}
+
+function verify_ldap_password() {
+  global $ldap_host, $ldap_basedn;
+  $ldaph=ldap_connect($ldap_host);
+  ldap_set_option($ldaph, LDAP_OPT_PROTOCOL_VERSION, 3);
+  if(@ldap_bind($ldaph,"uid=".$_REQUEST['nick'].",ou=people,".$ldap_basedn,$_REQUEST['password'])) {
+    return true;
+  }
+  return false;
 }
 
 function privileges_for_user($user_id) {

--- a/includes/sys_auth.php
+++ b/includes/sys_auth.php
@@ -40,7 +40,11 @@ function generate_salt($length = 16) {
  */
 function set_password($uid, $password) {
   global $crypt_alg;
-  $result = sql_query("UPDATE `User` SET `Passwort` = '" . sql_escape(crypt($password, $crypt_alg . '$' . generate_salt(16) . '$')) . "', `password_recovery_token`=NULL WHERE `UID` = " . intval($uid) . " LIMIT 1");
+  if (isset($_SESSION['ldap_user']) and $password == 'ldap-auth') {
+    $result = sql_query("UPDATE `User` SET `Passwort` = 'ldap-auth', `password_recovery_token`=NULL WHERE `UID` = " . intval($uid) . " LIMIT 1");
+  } else {  
+    $result = sql_query("UPDATE `User` SET `Passwort` = '" . sql_escape(crypt($password, $crypt_alg . '$' . generate_salt(16) . '$')) . "', `password_recovery_token`=NULL WHERE `UID` = " . intval($uid) . " LIMIT 1");
+  }
   if ($result === false) {
     engelsystem_error('Unable to update password.');
   }
@@ -80,10 +84,10 @@ function verify_password($password, $salt, $uid = false) {
 }
 
 function verify_ldap_password() {
-  global $ldap_host, $ldap_basedn;
+  global $ldap_host, $ldap_basedn ,$ldap_userou;
   $ldaph=ldap_connect($ldap_host);
   ldap_set_option($ldaph, LDAP_OPT_PROTOCOL_VERSION, 3);
-  if(@ldap_bind($ldaph,"uid=".$_REQUEST['nick'].",ou=users,".$ldap_basedn,$_REQUEST['password'])) {
+  if(@ldap_bind($ldaph,"uid=".ldap_escape($_REQUEST['nick']).",".$ldap_userou.",".$ldap_basedn,$_REQUEST['password'])) {
     return true;
   }
   return false;


### PR DESCRIPTION
Das Engelsystem authentifiziert jetzt zusätzlich gegen LDAP und holt sich da Nutzername und Email ab, normale Registrierung ohne ZaPF-Auth ist aber weiterhin möglich.